### PR TITLE
Fixes the project by using node 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build
+FROM lambci/lambda:build-nodejs8.10
 
 # working folder
 RUN mkdir /build

--- a/app.yml
+++ b/app.yml
@@ -39,7 +39,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       CodeUri: dist/lambda.zip
       Role: !GetAtt LambdaRole.Arn
       Environment:


### PR DESCRIPTION
Hi @rprieto! This PR fixes the following errors:

# Error when running npm install due to outdated node version
```
> node-pre-gyp install --fallback-to-build

node-pre-gyp ERR! UNCAUGHT EXCEPTION
node-pre-gyp ERR! stack TypeError: this is not a typed array.
node-pre-gyp ERR! stack     at Function.from (native)
node-pre-gyp ERR! stack     at Object.<anonymous> (/build/node_modules/htpasswd-auth/node_modules/bcrypt/node_modules/tar/lib/parse.js:33:27)
node-pre-gyp ERR! stack     at Module._compile (module.js:409:26)
node-pre-gyp ERR! stack     at Object.Module._extensions..js (module.js:416:10)
node-pre-gyp ERR! stack     at Module.load (module.js:343:32)
node-pre-gyp ERR! stack     at Function.Module._load (module.js:300:12)
node-pre-gyp ERR! stack     at Module.require (module.js:353:17)
node-pre-gyp ERR! stack     at require (internal/module.js:12:17)
node-pre-gyp ERR! stack     at Object.<anonymous> (/build/node_modules/htpasswd-auth/node_modules/bcrypt/node_modules/tar/lib/list.js:10:16)
node-pre-gyp ERR! stack     at Module._compile (module.js:409:26)
node-pre-gyp ERR! System Linux 4.9.125-linuxkit
node-pre-gyp ERR! command "/usr/local/lib64/node-v4.3.x/bin/node" "/build/node_modules/htpasswd-auth/node_modules/bcrypt/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /build/node_modules/htpasswd-auth/node_modules/bcrypt
node-pre-gyp ERR! node -v v4.3.2
node-pre-gyp ERR! node-pre-gyp -v v0.9.1
node-pre-gyp ERR! This is a bug in `node-pre-gyp`.
node-pre-gyp ERR! Try to update node-pre-gyp and file an issue if it does not help:
node-pre-gyp ERR!     <https://github.com/mapbox/node-pre-gyp/issues>
npm ERR! Linux 4.9.125-linuxkit
npm ERR! argv "/usr/local/lib64/node-v4.3.x/bin/node" "/usr/local/lib64/node-v4.3.x/bin/npm" "install" "--production"
npm ERR! node v4.3.2
npm ERR! npm  v2.14.12
npm ERR! code ELIFECYCLE

npm ERR! bcrypt@2.0.1 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 7
npm ERR!
npm ERR! Failed at the bcrypt@2.0.1 install script 'node-pre-gyp install --fallback-to-build'.
npm ERR! This is most likely a problem with the bcrypt package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-pre-gyp install --fallback-to-build
npm ERR! You can get their info via:
npm ERR!     npm owner ls bcrypt
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /build/npm-debug.log
The command '/bin/sh -c npm install --production' returned a non-zero code: 1
```

# Cloudformation error due to outdated node runtime

```
"ResourceType": "AWS::Lambda::Function",
"Timestamp": "2019-03-06T19:29:29.804Z",
"ResourceStatus": "CREATE_FAILED",
"ResourceStatusReason": "The runtime parameter of nodejs4.3 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs8.10) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 293eca2d-4046-11e9-ba29-bb469a323241)"
``` 